### PR TITLE
xml encoding exponential cost

### DIFF
--- a/gin/render.go
+++ b/gin/render.go
@@ -1,7 +1,7 @@
 package gin
 
 import (
-	"github.com/clbanning/mxj"
+	"github.com/clbanning/mxj/v2"
 	"github.com/gin-gonic/gin"
 	"github.com/luraproject/lura/v2/proxy"
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/krakend/krakend-xml/v2
 go 1.24.0
 
 require (
-	github.com/clbanning/mxj v1.8.4
+	github.com/clbanning/mxj/v2 v2.7.0
 	github.com/gin-gonic/gin v1.9.1
 	github.com/luraproject/lura/v2 v2.11.0
 	golang.org/x/net v0.47.0

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/bytedance/sonic v1.12.5/go.mod h1:B8Gt/XvtZ3Fqj+iSKMypzymZxw/FVwgIGKz
 github.com/bytedance/sonic/loader v0.1.1/go.mod h1:ncP89zfokxS5LZrJxl5z0UJcsk4M4yY2JpfqGeCtNLU=
 github.com/bytedance/sonic/loader v0.2.0 h1:zNprn+lsIP06C/IqCHs3gPQIvnvpKbbxyXQP1iU4kWM=
 github.com/bytedance/sonic/loader v0.2.0/go.mod h1:ncP89zfokxS5LZrJxl5z0UJcsk4M4yY2JpfqGeCtNLU=
-github.com/clbanning/mxj v1.8.4 h1:HuhwZtbyvyOw+3Z1AowPkU87JkJUSv751ELWaiTpj8I=
-github.com/clbanning/mxj v1.8.4/go.mod h1:BVjHeAH+rl9rs6f+QIpeRl0tfu10SXn1pUSa5PVGJng=
+github.com/clbanning/mxj/v2 v2.7.0 h1:WA/La7UGCanFe5NpHF0Q3DNtnCsVoxbPKuyBNHWRyME=
+github.com/clbanning/mxj/v2 v2.7.0/go.mod h1:hNiWqW14h+kc+MdF9C6/YoRfjEJoR3ou6tn/Qo+ve2s=
 github.com/cloudwego/base64x v0.1.4 h1:jwCgWpFanWmN8xoIUHa2rtzmkd5J2plF/dnLS6Xd/0Y=
 github.com/cloudwego/base64x v0.1.4/go.mod h1:0zlkT4Wn5C6NdauXdJRhSKRlJvmclQ1hhJgA0rcu/8w=
 github.com/cloudwego/iasm v0.2.0 h1:1KNIy1I1H9hNNFEEH3DVnI4UujN+1zjpuk6gwHLTssg=

--- a/xml.go
+++ b/xml.go
@@ -3,7 +3,7 @@ package xml
 import (
 	"io"
 
-	"github.com/clbanning/mxj"
+	"github.com/clbanning/mxj/v2"
 	"github.com/luraproject/lura/v2/encoding"
 	"golang.org/x/net/html/charset"
 )

--- a/xml_test.go
+++ b/xml_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/clbanning/mxj"
+	"github.com/clbanning/mxj/v2"
 )
 
 func TestNewDecoder_map(t *testing.T) {


### PR DESCRIPTION
Just by upgrading the mxj library to v2 we get a big improvement on time spent rendering the XML

Old times in **seconds**: 

<img width="400" height="230" alt="chart(1)" src="https://github.com/user-attachments/assets/ee9a5281-169f-45b1-aa5a-4819f28b0be6" />

**NEW** times in **seconds**:

<img width="400" height="230" alt="chart" src="https://github.com/user-attachments/assets/ef3741f3-76d7-4190-b198-4f58cb3c6818" />


**OLD** library version output:
```
 2026/04/07 - 08:51:32.140 [AccessLog] | 200 | 33.988ms |             ::1 | GET      /json/100
 2026/04/07 - 08:51:35.253 [AccessLog] | 200 | 3147.719ms |             ::1 | GET      /from/json/to/xml/100
 2026/04/07 - 08:51:35.269 [AccessLog] | 200 | 8.533ms |             ::1 | GET      /json/200
 2026/04/07 - 08:51:46.153 [AccessLog] | 200 | 10892.690ms |             ::1 | GET      /from/json/to/xml/200
 2026/04/07 - 08:51:46.172 [AccessLog] | 200 | 11.108ms |             ::1 | GET      /json/300
 2026/04/07 - 08:52:09.640 [AccessLog] | 200 | 23479.492ms |             ::1 | GET      /from/json/to/xml/300
 2026/04/07 - 08:52:09.661 [AccessLog] | 200 | 14.550ms |             ::1 | GET      /json/400
 2026/04/07 - 08:52:52.481 [AccessLog] | 200 | 42834.869ms |             ::1 | GET      /from/json/to/xml/400
 2026/04/07 - 08:52:52.508 [AccessLog] | 200 | 20.253ms |             ::1 | GET      /json/500
 2026/04/07 - 08:53:58.268 [AccessLog] | 200 | 65780.612ms |             ::1 | GET      /from/json/to/xml/500
 2026/04/07 - 08:53:58.298 [AccessLog] | 200 | 22.356ms |             ::1 | GET      /json/600
 2026/04/07 - 08:55:36.075 [AccessLog] | 200 | 97800.155ms |             ::1 | GET      /from/json/to/xml/600
 2026/04/07 - 08:55:36.109 [AccessLog] | 200 | 26.325ms |             ::1 | GET      /json/700
 2026/04/07 - 08:57:50.724 [AccessLog] | 200 | 134642.058ms |             ::1 | GET      /from/json/to/xml/700
 2026/04/07 - 08:57:50.761 [AccessLog] | 200 | 29.610ms |             ::1 | GET      /json/800
 2026/04/07 - 09:00:42.356 [AccessLog] | 200 | 171625.032ms |             ::1 | GET      /from/json/to/xml/800
 2026/04/07 - 09:00:42.395 [AccessLog] | 200 | 32.676ms |             ::1 | GET      /json/900
 2026/04/07 - 09:04:19.021 [AccessLog] | 200 | 216658.849ms |             ::1 | GET      /from/json/to/xml/900
 2026/04/07 - 09:04:19.062 [AccessLog] | 200 | 34.062ms |             ::1 | GET      /json/1000
 2026/04/07 - 09:08:53.065 [AccessLog] | 200 | 274037.140ms |             ::1 | GET      /from/json/to/xml/1000
```

**NEW** library version output:
```
 2026/04/07 - 08:45:38.134 [AccessLog] | 200 | 22.115ms |             ::1 | GET      /json/100
 2026/04/07 - 08:45:38.159 [AccessLog] | 200 | 48.212ms |             ::1 | GET      /from/json/to/xml/100
 2026/04/07 - 08:45:38.176 [AccessLog] | 200 | 9.576ms |             ::1 | GET      /json/200
 2026/04/07 - 08:45:38.200 [AccessLog] | 200 | 33.318ms |             ::1 | GET      /from/json/to/xml/200
 2026/04/07 - 08:45:38.219 [AccessLog] | 200 | 12.849ms |             ::1 | GET      /json/300
 2026/04/07 - 08:45:38.255 [AccessLog] | 200 | 49.016ms |             ::1 | GET      /from/json/to/xml/300
 2026/04/07 - 08:45:38.279 [AccessLog] | 200 | 17.159ms |             ::1 | GET      /json/400
 2026/04/07 - 08:45:38.325 [AccessLog] | 200 | 63.437ms |             ::1 | GET      /from/json/to/xml/400
 2026/04/07 - 08:45:38.352 [AccessLog] | 200 | 19.910ms |             ::1 | GET      /json/500
 2026/04/07 - 08:45:38.414 [AccessLog] | 200 | 82.233ms |             ::1 | GET      /from/json/to/xml/500
 2026/04/07 - 08:45:38.445 [AccessLog] | 200 | 24.077ms |             ::1 | GET      /json/600
 2026/04/07 - 08:45:38.518 [AccessLog] | 200 | 97.394ms |             ::1 | GET      /from/json/to/xml/600
 2026/04/07 - 08:45:38.547 [AccessLog] | 200 | 22.415ms |             ::1 | GET      /json/700
 2026/04/07 - 08:45:38.622 [AccessLog] | 200 | 97.697ms |             ::1 | GET      /from/json/to/xml/700
 2026/04/07 - 08:45:38.657 [AccessLog] | 200 | 28.374ms |             ::1 | GET      /json/800
 2026/04/07 - 08:45:38.747 [AccessLog] | 200 | 117.984ms |             ::1 | GET      /from/json/to/xml/800
 2026/04/07 - 08:45:38.790 [AccessLog] | 200 | 36.050ms |             ::1 | GET      /json/900
 2026/04/07 - 08:45:38.888 [AccessLog] | 200 | 134.972ms |             ::1 | GET      /from/json/to/xml/900
 2026/04/07 - 08:45:38.931 [AccessLog] | 200 | 35.948ms |             ::1 | GET      /json/1000
 2026/04/07 - 08:45:39.042 [AccessLog] | 200 | 146.737ms |             ::1 | GET      /from/json/to/xml/1000
```